### PR TITLE
fix(gt-not-hard): 修复addFakeVoidIngotRecipes_T10配方注册时的 NPE 问题

### DIFF
--- a/src/main/java/Recipes/SingularityRecipes_VoidIngot/FakeSingularityIngotRecipes.java
+++ b/src/main/java/Recipes/SingularityRecipes_VoidIngot/FakeSingularityIngotRecipes.java
@@ -6,6 +6,9 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static util.AggregateItemStackArray.addCompressAggregateArray;
 import static util.AggregateItemStackArray.addSplitAggregateArray;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.GTValues;
@@ -1523,11 +1526,29 @@ public class FakeSingularityIngotRecipes {
 
     public static void addFakeVoidIngotRecipes_T10() {
         // T10 - DeepDark - DD
-        ItemStack[][] Fake_T10_DeepDark_Ingot_Split = addSplitAggregateArray(Vein_Ingot.T10_Ingot, NEI_ItemOutput_Size);
-        for (ItemStack[] tempItemStacks : Fake_T10_DeepDark_Ingot_Split) {
+        ItemStack[][] splitArrays = addSplitAggregateArray(Vein_Ingot.T10_Ingot, NEI_ItemOutput_Size);
+
+        for (ItemStack[] tempItemStacks : splitArrays) {
+            List<ItemStack> validOutputs = new ArrayList<>();
+
+            if (tempItemStacks != null) {
+                for (ItemStack stack : tempItemStacks) {
+                    if (stack != null) {
+                        validOutputs.add(stack);
+                    }
+                }
+            }
+
+            // 如果没有有效输出，直接跳过这个配方
+            if (validOutputs.isEmpty()) {
+                continue;
+            }
+
+            ItemStack[] filteredOutputs = validOutputs.toArray(new ItemStack[0]);
+
             GTValues.RA.stdBuilder()
                 .itemInputs(getModItem(NEIOrePlugin.ID, "blockDimensionDisplay_DD", 1L))
-                .itemOutputs(tempItemStacks)
+                .itemOutputs(filteredOutputs)
                 .fake()
                 .duration(3 * SECONDS)
                 .setNEIDesc("Singularity with Void Ingot Mode")


### PR DESCRIPTION
问题描述:
https://github.com/z1564058782/GT-Not-Hard/issues/23 加载模组时崩溃，检查后发现是问题出在 GT Not Hard 模组 的 postInit 阶段，具体是在添加“假虚空流体配方”时，向 GregTech 的配方构建器传入了 null 值，导致 IllegalArgumentException。解决办法可以在传入该值时检查是否为null，如果是null则放弃该配方的注册，问题出现在SingularityFluidRecipes_T10.java的第4665行。 根本原因:
addSplitAggregateArray 方法返回的二维数组中可能包含 null 的 ItemStack， 直接传入 GTValues.RA.stdBuilder().itemOutputs() 会触发参数验证异常。

修复内容:
1. 遍历 tempItemStacks 数组，过滤掉所有 null 值
2. 将有效 ItemStack 收集到 validOutputs 列表
3. 如果 validOutputs 为空，跳过当前配方的注册
4. 将过滤后的数组传入 GT 配方构建器

代码变更:
- 添加 null 检查逻辑，确保不向 GT 传入无效参数
- 保持原有功能不变，仅增加安全性检查
- 修复位置：SingularityFluidRecipes_T10.java 的 addFakeVoidIngotRecipes_T10 方法

影响范围:
- 修复后模组在多模组环境下可正常加载，不会在配方注册阶段崩溃
- 跳过无效配方，不影响其他正常配方的功能